### PR TITLE
Update README with dependency information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,26 @@
 Generic versions of commonly used functions, implemented as multimethods
 that can be implemented for any data type.
 
+## Dependency
+
+In Maven:
+
+```xml
+<dependency>
+  <groupId>org.clojure</groupId>
+  <artifactId>algo.generic</artifactId>
+  <version>0.1.0</version>
+</dependency>
+```
+
+In Leiningen:
+
+```clj
+  :dependencies [...
+                 [org.clojure/algo.generic "0.1.0"]
+                 ...]
+```
+
 ## Usage
 
 Each submodule of clojure.algo.generic defines a set of related


### PR DESCRIPTION
It's really useful to have dependency information in the readme, especially considering that the repository version of the pom.xml often has a development number that doesn't reflect the latest released number.
