### PR TITLE
added Math functions from java 6

### DIFF
--- a/src/main/clojure/clojure/algo/generic/math_functions.clj
+++ b/src/main/clojure/clojure/algo/generic/math_functions.clj
@@ -74,6 +74,16 @@
 (defmathfn-1 sqrt)
 (defmathfn-1 tan)
 
+;; http://docs.oracle.com/javase/6/docs/api/java/lang/Math.html
+(defmathfn-1 cbrt)
+(defmathfn-1 cosh)
+(defmathfn-1 expm1)
+(defmathfn-2 hypot)
+(defmathfn-1 log10)
+(defmathfn-1 log1p)
+(defmathfn-1 sinh)
+(defmathfn-1 tanh)
+
 ;
 ; Sign
 ;


### PR DESCRIPTION
Since there were some functions missing from http://docs.oracle.com/javase/6/docs/api/java/lang/Math.html,
I added them to /clojure/algo/generic/math_functions.clj.
